### PR TITLE
:hammer: Add basic build pipeline

### DIFF
--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -1,0 +1,37 @@
+name: On push main
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        arch: [arm64, amd64]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+          cache: true
+
+      - name: Test
+        run: go test
+
+      - name: Build
+        run: ./scripts/build.sh
+        env:
+          ARCH: ${{ matrix.arch }}
+
+      - name: Bundle layer
+        uses: actions/upload-artifact@v3
+        with:
+          name: extension-${{ matrix.arch }}
+          path: bin/

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,0 @@
-build:
-	GOOS=linux GOARCH=amd64 go build -o bin/extensions/go-example-extension main.go
-
-build-GoExampleExtensionLayer:
-	GOOS=linux GOARCH=amd64 go build -o $(ARTIFACTS_DIR)/extensions/go-example-extension main.go
-	chmod +x $(ARTIFACTS_DIR)/extensions/go-example-extension
-
-run-GoExampleExtensionLayer:
-	go run go-example-extension/main.go

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,8 +1,6 @@
 # shellcheck disable=SC2164
-GOOS=linux GOARCH=amd64 go build -o bin/extensions/go-example-extension main.go
-chmod +x bin/extensions/go-example-extension
-cd bin
-zip -r extension.zip extensions/
+./scripts/build.sh
+./scripts/bundle.sh
 
 aws lambda publish-layer-version \
  --layer-name "Secrets-Lambda-Extension-Layer" \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "Building for architecture ${ARCH:-amd64}..."
+GOOS=linux GOARCH=${ARCH} go build -o bin/extensions/go-example-extension main.go
+chmod +x bin/extensions/go-example-extension
+echo "Building finished."

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "Bundeling layer..."
+cd bin
+zip -r extension.zip extensions/
+echo "Bundeling finished."


### PR DESCRIPTION
This PR adds a basic ci pipeline that 
* Run the tests
* Build the lambda layer for arm64 and amd64 architecture
* Bundle the artifact as zip 

Aside that the makefile is deleted because not used