### PR TITLE
feat: Serve secrets cache by a webserver

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -4,7 +4,7 @@
 
 aws lambda publish-layer-version \
  --layer-name "Secrets-Lambda-Extension-Layer" \
- --zip-file  "fileb://extension.zip"
+ --zip-file  "fileb://bin/extension.zip"
 
 aws lambda update-function-configuration \
  --function-name foobar \

--- a/extension/secrets.go
+++ b/extension/secrets.go
@@ -20,6 +20,8 @@ type Secret struct {
 	SecretId, SecretString string
 }
 
+var secretsCache = make(map[string]Secret)
+
 func LoadSecrets() {
 	// log current timestamp
 	fmt.Println("Loading secrets...")
@@ -27,9 +29,21 @@ func LoadSecrets() {
 
 	secretIds := readSecretIdsFromEnvironmentWhenStartsWithSecret()
 	secrets := getSecretValuesFromListOfSecretIds(secretIds, getSecretValue)
-	writeSecrets(secrets)
+
+	fillSecretsCache(secrets)
+	// writeSecrets(secrets)
 
 	fmt.Println("Finished loading secrets on", time.Now().UnixMilli())
+}
+
+func GetSecretFromCache(secretName string) Secret {
+	return secretsCache[secretName]
+}
+
+func fillSecretsCache(secrets []Secret) {
+	for _, secret := range secrets {
+		secretsCache[secret.SecretId] = secret
+	}
 }
 
 func readSecretIdsFromEnvironmentWhenStartsWithSecret() []string {

--- a/go.mod
+++ b/go.mod
@@ -24,5 +24,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.11.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.13 // indirect
 	github.com/aws/smithy-go v1.12.1 // indirect
+	github.com/gorilla/mux v1.8.0
 	github.com/stretchr/testify v1.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"aws-lambda-go-secret-cache-extension/extension"
+	"aws-lambda-go-secret-cache-extension/webserver"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -43,7 +44,10 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	// Preload secrets
 	extension.LoadSecrets()
+	// Start HTTP server
+	webserver.Start("4000")
 
 	println(printPrefix, "Register response:", prettyPrint(res))
 

--- a/webserver/server.go
+++ b/webserver/server.go
@@ -1,0 +1,33 @@
+package webserver
+
+import (
+	"aws-lambda-go-secret-cache-extension/extension"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+func Start(port string) {
+	go startHTTPServer(port)
+}
+
+func startHTTPServer(port string) {
+	router := mux.NewRouter()
+	router.Path("/secrets").Queries("name", "{name}").HandlerFunc(
+		func(writer http.ResponseWriter, request *http.Request) {
+			variables := mux.Vars(request)
+			secret := extension.GetSecretFromCache(variables["name"])
+
+			if len(secret.SecretString) != 0 {
+				_, _ = writer.Write([]byte(secret.SecretString))
+			} else {
+				_, _ = writer.Write([]byte("No secret found"))
+			}
+		})
+
+	println("Starting http server on port: ", port)
+	err := http.ListenAndServe(":"+port, router)
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
Have a simple secrets cache and serve it by a webserver.

Works when deployed and using the following very basic example function:
```javascript
const https = require('http');

exports.handler = function(event, context, callback) {

    const secretName = process.env.SECRET_MYSECRET
    const options = {
        hostname: 'localhost',
        port: 4000,
        path: `/secrets?name=${secretName}`,
        method: 'GET'
    };

    const req = https.request(options, res => {
        res.on('data', d => {
            console.log("Retrieved secret from the cache: "+d);
            return d;
        });
    });

    req.on('error', error => {
        console.error(error);
    });

    req.end();
};
```